### PR TITLE
Require auth for cloud. Otherwise it will just ignore getting a token…

### DIFF
--- a/src/xray-cloud.ts
+++ b/src/xray-cloud.ts
@@ -18,7 +18,7 @@ export class XrayCloud implements Xray {
   token = ''
 
   // XrayCloud requires to authenticate with the given credentials first
-  requiresAuth = false
+  requiresAuth = true
 
   constructor(
     private xrayOptions: XrayOptions,


### PR DESCRIPTION
… and fail with a 401.
Seems to have been broken with 2.2.0