### PR TITLE
fix(466): output testExecKey for a single report

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -124,7 +124,7 @@ export class Processor {
 
       // if no test exec key was specified we wanna execute once and then update the testExec for the remaining imports
       if (
-        files.length > 1 &&
+        files.length > 0 &&
         !this.xrayImportOptions.testExecKey &&
         this.importOptions.combineInSingleTestExec
       ) {
@@ -142,11 +142,13 @@ export class Processor {
         }
       }
 
-      // execute all remaining in parallel
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const {results} = await PromisePool.for(files)
-        .withConcurrency(this.importOptions.importParallelism)
-        .process(async file => await doImport(file))
+      if (files.length > 0) {
+        // execute all remaining in parallel
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {results} = await PromisePool.for(files)
+          .withConcurrency(this.importOptions.importParallelism)
+          .process(async file => await doImport(file))
+      }
     } catch (error: any /* eslint-disable-line @typescript-eslint/no-explicit-any */) {
       core.warning(`🔥 Stopped import (${error.message})`)
     }


### PR DESCRIPTION
testExecKey only appears in output if there are multiple report files. Today some reporters such as jest-junit merge reports by themselves. 

This change is proposed to solve this issue: https://github.com/mikepenz/xray-action/issues/466 

