### PR TITLE
issues-845: added custom response timeout to control API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If you're using Xray Server/DC, you'll need to set `xrayCloud` as "false", use J
 | `failOnImportError`       | Defines if the action should fail if an import error occurred. (Default: false)                                                                                |              |
 | `continueOnImportError`   | Defines if the action should continue after a single import error occurred. (Default: true)                                                                    |              |
 | `importParallelism`       | Specifies the level of parallelism to import to Xray. (Default: 2)                                                                                             |              |
+| `responseTimeout`       | Specifies the maximum duration for a request (in milliseconds) to wait for a response to execute before timing out. The default is 60000 milliseconds.                                                                                             |              |
 | `testExecutionJson`       | File path to a json file, containing the meta information to create the xray test execution ticket.                                                                           |              |
 | `testJson`       | File path to a json file, containing the meta information to create the xray test ticket.                                                                           |              |
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -27,7 +27,8 @@ test('import test results server', async () => {
       combineInSingleTestExec: true,
       failOnImportError: true,
       continueOnImportError: true,
-      importParallelism: 2
+      importParallelism: 2,
+      responseTimeout: 60000
     }
   )
   const result = await processor.process()
@@ -71,7 +72,8 @@ test('import test results server', async () => {
       combineInSingleTestExec: true,
       failOnImportError: false,
       continueOnImportError: true,
-      importParallelism: 2
+      importParallelism: 2,
+      responseTimeout: 60000
     }
   )
   const result = await processor.process()
@@ -113,7 +115,8 @@ test('import cucumber test results server', async () => {
       combineInSingleTestExec: true,
       failOnImportError: false,
       continueOnImportError: true,
-      importParallelism: 2
+      importParallelism: 2,
+      responseTimeout: 60000
     }
   )
   const result = await processor.process()
@@ -121,7 +124,6 @@ test('import cucumber test results server', async () => {
 
 /*
 test('import test results cloud', async () => {
-  
   const processor = new Processor(
     {
       cloud: true,
@@ -132,6 +134,7 @@ test('import test results cloud', async () => {
     {
       testFormat: "junit",
       testPaths: "marathon_tests/*.xml",
+      testMerge: true,
       testExecKey: "",
       projectKey: "TA",
       testPlanKey: "TA-33",
@@ -157,7 +160,8 @@ test('import test results cloud', async () => {
       combineInSingleTestExec: true,
       failOnImportError: false,
       continueOnImportError: true,
-      importParallelism: 2
+      importParallelism: 2,
+      responseTimeout: 60000
     }
   )
   const result = await processor.process()

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: 'Specifies the level of parallelism to import to Xray.'
     required: false
     default: "2"
+  responseTimeout:
+    description: 'Specifies the maximum duration for a request (in milliseconds) to wait for a response to execute before timing out. The default is 60 seconds.'
+    required: false
+    default: "60000"
   testExecutionJson:
     description: 'Links to a json file, defining the meta information to create the test execution ticket.'
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,8 @@ async function run(): Promise<void> {
       core.getInput('continueOnImportError') === 'true'
     const importParallelism: number =
       Number(core.getInput('importParallelism')) || 2 // by default go to 2 parallelism
+    const responseTimeout: number =
+      Number(core.getInput('responseTimeout')) || 60000 // by default 60s
 
     await new Processor(
       {
@@ -88,7 +90,8 @@ async function run(): Promise<void> {
         combineInSingleTestExec,
         failOnImportError,
         continueOnImportError,
-        importParallelism
+        importParallelism,
+        responseTimeout
       }
     ).process()
   } catch (error: any /* eslint-disable-line @typescript-eslint/no-explicit-any */) {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -34,6 +34,7 @@ export interface ImportOptions {
   failOnImportError: boolean
   continueOnImportError: boolean
   importParallelism: number
+  responseTimeout: number
 }
 
 export class Processor {
@@ -48,10 +49,18 @@ export class Processor {
 
     let xray: Xray
     if (this.xrayOptions.cloud) {
-      xray = new XrayCloud(this.xrayOptions, this.xrayImportOptions)
+      xray = new XrayCloud(
+        this.xrayOptions,
+        this.xrayImportOptions,
+        this.importOptions
+      )
       core.info('ℹ️ Configured XrayCloud')
     } else {
-      xray = new XrayServer(this.xrayOptions, this.xrayImportOptions)
+      xray = new XrayServer(
+        this.xrayOptions,
+        this.xrayImportOptions,
+        this.importOptions
+      )
       core.info('ℹ️ Configured XrayServer')
     }
 

--- a/src/xray-cloud.ts
+++ b/src/xray-cloud.ts
@@ -1,4 +1,4 @@
-import {XrayImportOptions, XrayOptions} from './processor'
+import {XrayImportOptions, XrayOptions, ImportOptions} from './processor'
 import got from 'got'
 import * as core from '@actions/core'
 import FormData from 'form-data'
@@ -22,7 +22,8 @@ export class XrayCloud implements Xray {
 
   constructor(
     private xrayOptions: XrayOptions,
-    private xrayImportOptions: XrayImportOptions
+    private xrayImportOptions: XrayImportOptions,
+    private importOptions: ImportOptions
   ) {
     this.searchParams = createSearchParams(this.xrayImportOptions)
   }
@@ -61,6 +62,7 @@ export class XrayCloud implements Xray {
   async import(data: Buffer, mimeType: string): Promise<string> {
     // do import
     let format = this.xrayImportOptions.testFormat
+    const responseTimeout = this.importOptions.responseTimeout
     if (format === 'xray') {
       format = '' // xray format has no subpath
     } else {
@@ -146,7 +148,7 @@ export class XrayCloud implements Xray {
         },
         body: data,
         responseType: 'json',
-        timeout: 60000, // 60s timeout
+        timeout: responseTimeout, // default timeout 60s
         retry: 2, // retry count for some requests
         http2: true // try to allow http2 requests
       })

--- a/src/xray-server.ts
+++ b/src/xray-server.ts
@@ -1,4 +1,4 @@
-import {XrayImportOptions, XrayOptions} from './processor'
+import {XrayImportOptions, XrayOptions, ImportOptions} from './processor'
 import got from 'got'
 import * as core from '@actions/core'
 import FormData from 'form-data'
@@ -21,7 +21,8 @@ export class XrayServer implements Xray {
 
   constructor(
     private xrayOptions: XrayOptions,
-    private xrayImportOptions: XrayImportOptions
+    private xrayImportOptions: XrayImportOptions,
+    private importOptions: ImportOptions
   ) {
     this.xrayBaseUrl =
       this.xrayOptions.baseUrl || new URL('https://sandbox.xpand-it.com')
@@ -48,6 +49,7 @@ export class XrayServer implements Xray {
   async import(data: Buffer, mimeType: string): Promise<string> {
     // do import
     let format = this.xrayImportOptions.testFormat
+    const responseTimeout = this.importOptions.responseTimeout
     if (format === 'xray') {
       format = '' // xray format has no subpath
     } else {
@@ -181,7 +183,7 @@ export class XrayServer implements Xray {
           },
           body: data,
           responseType: 'json',
-          timeout: 60000 // 60s timeout
+          timeout: responseTimeout // default timeout 60s
         })
         try {
           if (core.isDebug()) {


### PR DESCRIPTION
hey @mikepenz, please have a look into these changes

1. Added custom timeout (**not required**) that can be set from GH Actions to fix the issue https://github.com/mikepenz/xray-action/issues/845
2. Some of the XML files can have 500-1000 tests in them and XRay cloud takes time to respond, our framework has 40+ rejected API requests per night due to timeout in 60 seconds.

Example of importing XML file directly to XRay cloud from Postman(there is no default timeout defined in Postman)
![xray-import-1minute](https://github.com/user-attachments/assets/bcaf89b1-7397-4381-a2dc-b2abfeda6fb3)
