### PR TITLE
chore(deps): security update js-yaml 5.2.2 and brace-expansion 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-prettier": "5.5.6",
         "globals": "17.7.0",
-        "js-yaml": "5.2.1",
+        "js-yaml": "5.2.2",
         "prettier": "3.9.5",
         "typescript": "6.0.3",
         "vitest": "4.1.10"
@@ -1846,15 +1846,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4041,9 +4041,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {
@@ -4593,9 +4593,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4951,9 +4951,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -4971,7 +4971,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -56,14 +56,13 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-prettier": "5.5.6",
     "globals": "17.7.0",
-    "js-yaml": "5.2.1",
+    "js-yaml": "5.2.2",
     "prettier": "3.9.5",
     "typescript": "6.0.3",
     "vitest": "4.1.10"
   },
   "overrides": {
-    "brace-expansion": "5.0.7",
-    "vite": "8.1.4",
+    "brace-expansion": "5.0.8",
     "undici": "8.7.0"
   }
 }


### PR DESCRIPTION
Mirrors the security merges already done on [release-changelog-builder-action@0fdd798](https://github.com/mikepenz/release-changelog-builder-action/commit/0fdd798) and [action-junit-report@250bc04](https://github.com/mikepenz/action-junit-report/commit/250bc04).

## Changes

- `js-yaml` `5.2.1` → `5.2.2` — GHSA-pm4m-ph32-ghv5
- `brace-expansion` override `5.0.7` → `5.0.8` — GHSA-mh99-v99m-4gvg / CVE-2026-14257
- dropped the `vite` override, no longer needed to keep the audit clean
- refreshed `postcss` in the lock file to `8.5.24` — GHSA-r28c-9q8g-f849

`undici` is kept at `8.7.0`, as it otherwise resolves back to 6.x. `brace-expansion` is still required because `minimatch` pulls in a vulnerable range.

### Note on `postcss`

Unlike the sibling repos, dropping the `vite` override here alone left `postcss@8.5.16` exposed to GHSA-r28c-9q8g-f849 — RCB avoided this only because its lock file had been refreshed by a separate lock file maintenance run. `npm update postcss` resolves it to `8.5.24` within the existing semver range, so no new override is needed.

## Verification

Run in a `node:24-alpine` container:

- `npm audit --audit-level=high` → **found 0 vulnerabilities**
- `npm run all` (build + format + lint + package + test) → pass, 3/3 tests

`dist/` is intentionally not included, matching the sibling security commits — the rebuild delta is pre-existing drift on `main` and only devDependencies changed here.

## Supersedes

- #1195 (renovate js-yaml)
- #1194 (dependabot js-yaml)